### PR TITLE
feat(collapsible-element): introduce collapsible-element

### DIFF
--- a/demo/polyfills/index.js
+++ b/demo/polyfills/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import 'core-js/modules/es6.array.find';
 import 'core-js/modules/es6.array.from';
 import 'core-js/modules/es6.math.sign';
 import 'core-js/modules/es6.object.assign';

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "npm": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
+    "@ibm/motion": "^0.2.1",
     "carbon-icons": "^6.0.4",
     "flatpickr": "2.6.3",
     "lodash.debounce": "^4.0.8"
   },
   "devDependencies": {
-    "@ibm/motion": "^0.2.1",
     "adaro": "1.0.4",
     "babel-core": "^6.22.0",
     "babel-eslint": "^7.0.0",

--- a/src/components/collapsible-element/collapsible-element.js
+++ b/src/components/collapsible-element/collapsible-element.js
@@ -1,0 +1,102 @@
+import mixin from '../../globals/js/misc/mixin';
+import createComponent from '../../globals/js/mixins/create-component';
+import eventedState from '../../globals/js/mixins/evented-state';
+import getDuration from '../../globals/js/misc/motion-getDuration';
+
+/**
+ * Collapsible element.
+ * @class CollapsibleElement
+ * @extends CreateComponent
+ * @extends EventedState
+ * @param {HTMLElement} element The element working as a collapsible element.
+ * @param {Object} [options] The component options.
+ * @param {Element} [options.stateNode]
+ *   The element that the CSS classes representing expanded/transient/collapsed states should be applied.
+ * @param {string} [options.classExpanded] The CSS class for the expanded state.
+ * @param {string} [options.classTransient] The CSS class for the transient state.
+ */
+class CollapsibleElement extends mixin(createComponent, eventedState) {
+  /**
+   * @param {string} state The new state.
+   * @returns {boolean} `true` if the given `state` is different from current state.
+   */
+  shouldStateBeChanged(state) {
+    const stateNode = this.options.stateNode || this.element;
+    const expanded = Boolean(this.options.classExpanded && stateNode.classList.contains(this.options.classExpanded));
+    return (state === 'expanded') !== expanded;
+  }
+
+  /**
+   * Changes the expanded/collapsed state.
+   * @private
+   * @param {string} state The new state.
+   * @param {Object} detail The detail of the event trigging this action.
+   * @param {Function} callback Callback called when change in state completes.
+   */
+  _changeState(state, detail, callback) {
+    const element = this.element;
+    const stateNode = this.options.stateNode || element;
+    const expanded = state === 'expanded';
+    const w = element.ownerDocument.defaultView;
+
+    const classTransient = this.options.classTransient;
+    const classExpanded = this.options.classExpanded;
+
+    const transitionEnd = () => {
+      element.removeEventListener('transitionend', transitionEnd);
+      if (classTransient) {
+        stateNode.classList.remove(classTransient);
+      }
+      element.style.height = '';
+      element.style.transitionDuration = '';
+      callback();
+    };
+
+    if (classExpanded) {
+      stateNode.classList.toggle(classExpanded, expanded);
+    }
+    if (classTransient) {
+      stateNode.classList.add(classTransient);
+    }
+
+    w.requestAnimationFrame(() => {
+      const height = this.element.scrollHeight;
+      element.style.height = expanded ? '0px' : `${height}px`;
+
+      w.requestAnimationFrame(() => {
+        element.style.transitionDuration = `${getDuration(height, element.offsetWidth, 'scale', 'mechanical')}ms`;
+        element.style.height = expanded ? `${height}px` : '0px';
+        element.addEventListener('transitionend', transitionEnd);
+      });
+    });
+  }
+
+  static components = new WeakMap();
+
+  /**
+   * The component options.
+   * If `options` is specified in the constructor, {@linkcode CollapsibleElement.create .create()},
+   * properties in this object are overriden for the instance being created.
+   * @member CollapsibleElement.options
+   * @property {string} [eventBeforeExpanded]
+   *   The name of the custom event fired before this element is expanded.
+   *   Cancellation of this event stops showing the element.
+   * @property {string} [eventAfterExpanded]
+   *   The name of the custom event telling that this element is sure expanded
+   *   without being canceled by the event handler named by `eventBeforeExpanded` option (`collapsible-element-beingexpanded`).
+   * @property {string} [eventBeforeCollapsed]
+   *   The name of the custom event fired before this element is collapsed.
+   *   Cancellation of this event stops hiding the element.
+   * @property {string} [eventAfterCollapsed]
+   *   The name of the custom event telling that this element is sure collapsed
+   *   without being canceled by the event handler named by `eventBeforeCollapsed` option (`collapsible-element-beingcollapsed`).
+   */
+  static options = {
+    eventBeforeExpanded: 'collapsible-element-beingexpanded',
+    eventAfterExpanded: 'collapsible-element-expanded',
+    eventBeforeCollapsed: 'collapsible-element-beingcollapsed',
+    eventAfterCollapsed: 'collapsible-element-collapsed',
+  };
+}
+
+export default CollapsibleElement;

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -75,9 +75,9 @@
     background-color: $ui-01;
     transition: height $transition--expansion $bx--ease-in-out 0ms;
 
-    .bx--dropdown-item{
-      opacity:0;
-      transition:opacity $transition--fade $bx--ease-in 0.2s;
+    .bx--dropdown-item {
+      opacity: 0;
+      transition: opacity $transition--fade $bx--ease-in 0.2s;
     }
   }
 
@@ -108,55 +108,52 @@
       transform: rotate(-180deg);
     }
 
+    .bx--dropdown-list .bx--dropdown-item {
+      opacity: 1;
+    }
+  }
+
+  .bx--dropdown--open, .bx--dropdown--transient {
     &:focus {
       .bx--dropdown-list {
         box-shadow: 0 1px 0 0 $brand-01, 1px 0 0 0 $brand-01, -1px 0 0 0 $brand-01;
       }
     }
-  }
 
-  .bx--dropdown-list--open {
-    @include typescale('zeta');
-    display: flex;
-    flex-direction: column;
-    height:auto;
-    transition: height $transition--expansion $bx--ease-in-out;
-
-    .bx--dropdown-item{
-      opacity:1;
-      transition:opacity $transition--fade $bx--ease-out $transition--delay-unit*9;
-
-      &:nth-child(1){
-        opacity:1;
-        transition:opacity $transition--fade $bx--ease-out $transition--delay-unit*1;
-      }
-      &:nth-child(2){
-        opacity:1;
-        transition:opacity $transition--fade $bx--ease-out $transition--delay-unit*2;
-      }
-      &:nth-child(3){
-        opacity:1;
-        transition:opacity $transition--fade $bx--ease-out $transition--delay-unit*3;
-      }
-      &:nth-child(4){
-        opacity:1;
-        transition:opacity $transition--fade $bx--ease-out $transition--delay-unit*4;
-      }
-      &:nth-child(5){
-        opacity:1;
-        transition:opacity $transition--fade $bx--ease-out $transition--delay-unit*5;
-      }
-      &:nth-child(6){
-        opacity:1;
-        transition:opacity $transition--fade $bx--ease-out $transition--delay-unit*6;
-      }
-      &:nth-child(7){
-        opacity:1;
-        transition:opacity $transition--fade $bx--ease-out $transition--delay-unit*7;
-      }
-      &:nth-child(8){
-        opacity:1;
-        transition:opacity $transition--fade $bx--ease-out $transition--delay-unit*8;
+    .bx--dropdown-list {
+      @include typescale('zeta');
+      display: flex;
+      flex-direction: column;
+      height: auto;
+      transition: height $transition--expansion $bx--ease-in-out;
+  
+      .bx--dropdown-item {
+        transition: opacity $transition--fade $bx--ease-out $transition--delay-unit * 9;
+  
+        &:nth-child(1) {
+          transition: opacity $transition--fade $bx--ease-out $transition--delay-unit * 1;
+        }
+        &:nth-child(2) {
+          transition: opacity $transition--fade $bx--ease-out $transition--delay-unit * 2;
+        }
+        &:nth-child(3) {
+          transition: opacity $transition--fade $bx--ease-out $transition--delay-unit * 3;
+        }
+        &:nth-child(4) {
+          transition: opacity $transition--fade $bx--ease-out $transition--delay-unit * 4;
+        }
+        &:nth-child(5) {
+          transition: opacity $transition--fade $bx--ease-out $transition--delay-unit * 5;
+        }
+        &:nth-child(6) {
+          transition: opacity $transition--fade $bx--ease-out $transition--delay-unit * 6;
+        }
+        &:nth-child(7) {
+          transition: opacity $transition--fade $bx--ease-out $transition--delay-unit * 7;
+        }
+        &:nth-child(8) {
+          transition: opacity $transition--fade $bx--ease-out $transition--delay-unit * 8;
+        }
       }
     }
   }

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -126,7 +126,9 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
       this.children.push(this.collapsible);
     }
     this.collapsible.changeState(state, detail, () => {
-      this.element.focus();
+      if (!detail.launchingEvent || !/^focus(in)?$/.test(detail.launchingEvent.type)) {
+        this.element.focus();
+      }
       if (callback) {
         callback();
       }


### PR DESCRIPTION
## Overview

This change introduces `CollapsibleElement` JavaScript class as discussed.
Also this change introduces `bx--dropdown--transient` CSS class, given the fact that there are two group of elements wrt when the styling is applied upon user action:

1. Ones whose style should be applied in the intermediate state as well as open state: e.g. Dropdown shown/hidden state and the focused state of dropdown list
2. Ones whose style should be applied as soon as open/closed state is changed: The triangle of the trigger button and the transparent/opaque state of dropdown items

Introduction of `bx--dropdown--transient` CSS class allows our JavaScript code to deal with the least number of CSS classes, regardless of how many elements are in either of above categories.

The styles are updated to reflect `bx--dropdown--transient` introduction. I believe none of your newly added animations is broken, but please feel free to ping me if you find otherwise. Thanks!

### Added

* `CollapsibleElement` JavaScript class
* `bx--dropdown--transient` CSS class

### Changed

Dropdown to use the new `CollapsibleElement` JavaScript class 

## Testing / Reviewing

Testing should make sure none of your newly added animation is broken.